### PR TITLE
Make README more concise and add dependency installation for externally-managed environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,58 @@
-# GitCode - LeetCode to GitHub Exporter
-Use this tool to download your solutions from [LeetCode.com](leetcode.com) and [CodeChef.com](codechef.com) to your local machine. The tool will go through your account and download all the solutions you have submitted so far. It also takes the questions from the website and saves them in a folder with the same name as the question. The tool will also create a ```README.md``` file for each question and add the question description to it. 
+# GitCode & GitChef
 
-## Supported operations
-- Support both O-Auth and User-Pass login system for LeetCode.
-- Let's you login to your LeetCode account. No need to worry about your password being stored anywhere.
-- Saves all your solutions to your local machine.
-- Each solution is saved in a separate file with the same name as the question, inside a folder with the same name as the question.
-- You can specify the path to the folder where you want to save your solutions.
-- The script will also create a ```README.md``` file for each question and add the question description to it.
-- The newly made solution files will be added to your local git repository and committed.
-- The changes will be pushed and uploaded to your GitHub repository.
+These tools make it possible to extract all your solutions from [LeetCode](https://leetcode.com/) and
+[CodeChef](https://codeshef.com) to your local machine and commit them to a git repository.
 
----
+## Features
 
-###  HOW TO [For Local Only]
-- [IMPORTANT] Pre-Configure GitHub account on your computer.
-- Fork this repository.
-- Clone the forked repoistory anywhere on your computer. 
-- Run GitCode.py
-###  HOW TO [For Github Upload]
-- [IMPORTANT] Pre-Configure GitHub account on your computer.
-- Clone your ```destination repository``` anywhere on your computer. 
-- Copy GitCode.py to the repository where you want to save your solutions.
-- Run GitCode.py
+- Supports O-Auth login
+- Supports user-pass login
+- Creates folder for every of your problem solutions
+- Exports all of your problem solutions in separate folders
+- Additionally, exports problem descriptions with them
+- Specify path for problem solutions
+- Commit solution to git repository
 
----
+## Usage
 
-# GitChef - CodeChef to GitHub Exporter [Documentation Pending]
+- [Setup Git](https://docs.github.com/en/get-started/quickstart/set-up-git) with your GitHub account on your local
+  machine
+- Optionally [Fork](/fork) this repository
+- Clone the repository on your local machine
+- Install the projects' dependencies (see [Dependencies](#Dependencies))
+- Run either `GitCode.py` or `GitChef.py` with:
+    - `python ./GitCode/GitCode.py`
+    - `python ./GitChef/GitChef.py`
 
-### Contibutions and Feedback are welcome | 2023 - [Sabyasachi Seal](https://github.com/Sabyasachi-Seal)
+### Dependencies
 
-Other contributors - [AdityaSeth777](https://github.com/AdityaSeth777), [Ayush786113](https://github.com/Ayush786113)
+This project requires a working Python 3.6+ installation. If the `pip` package manager is installed and the system is
+not externally managed (e.g. by the Linux distribution), the Python dependencies are installed automatically. If it is
+externally managed, you need to install the packages listed in the `requirements.txt` file or use one of the commands
+for your Linux distribution.
+
+#### Arch Linux
+
+This assumes that the AUR package install helper `paru` is installed. If another one is used, it can usually be
+substituted with its name or the listed packages are cloned and built itself with `makepkg`.
+
+```shell
+# Install dependencies for GitCode
+pacman -S python-pysocks python-async_generator python-attrs python-certifi python-charset-normalizer \
+          python-exceptiongroup python-h11 python-idna python-outcome python-packaging python-dotenv \
+          python-requests python-sniffio python-sortedcontainers python-tqdm python-trio python-trio-websocket \
+          python-urllib3 python-wsproto
+paru -S python-selenium python-webdriver-manager python-pybrowsers python-poetry
+
+# Install dependencies for GitChef
+pacman -S python-html5lib python-lxml python-requests
+paru -S python-bs4
+```
+
+## Contributors
+
+Contributions and feedback are welcome!
+
+- [Sabyasachi Seal](https://github.com/Sabyasachi-Seal)
+- [AdityaSeth777](https://github.com/AdityaSeth777)
+- [Ayush786113](https://github.com/Ayush786113)

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ These tools make it possible to extract all your solutions from [LeetCode](https
 
 - [Setup Git](https://docs.github.com/en/get-started/quickstart/set-up-git) with your GitHub account on your local
   machine
-- Optionally [Fork](/fork) this repository
+- Optionally [fork](https://github.com/Sabyasachi-Seal/GitCode/fork) this repository
 - Clone the repository on your local machine
 - Install the projects' dependencies (see [Dependencies](#Dependencies))
-- Run either `GitCode.py` or `GitChef.py` with:
-    - `python ./GitCode/GitCode.py`
-    - `python ./GitChef/GitChef.py`
+- Run either `GitCode.py` or `GitChef.py` from the project root folder with:
+    - `cd GitCode && python ./GitCode.py`
+    - `cd GitChef && python ./GitChef.py`
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ substituted with its name or the listed packages are cloned and built itself wit
 
 ```shell
 # Install dependencies for GitCode
-pacman -S python-pysocks python-async_generator python-attrs python-certifi python-charset-normalizer \
-          python-exceptiongroup python-h11 python-idna python-outcome python-packaging python-dotenv \
-          python-requests python-sniffio python-sortedcontainers python-tqdm python-trio python-trio-websocket \
+pacman -S python-pysocks python-async_generator python-attrs python-certifi \
+          python-charset-normalizer python-exceptiongroup python-h11 python-idna \
+          python-outcome python-packaging python-dotenv python-requests python-sniffio \
+          python-sortedcontainers python-tqdm python-trio python-trio-websocket \
           python-urllib3 python-wsproto
 paru -S python-selenium python-webdriver-manager python-pybrowsers python-poetry
 


### PR DESCRIPTION
I had some problems while using this tool, because I run a pip installation which is externally managed by my operating system. Therefore, I needed to find the packages from my package manager. To make it easier to use the tool I added a dependency section to the README and made the README a little more concise overall, I hope you don't mind. I can revert or adapt the README in any way, if that's needed.